### PR TITLE
NHIRS-8 - Improve memory usage for large raster input

### DIFF
--- a/hazimp/raster.py
+++ b/hazimp/raster.py
@@ -44,9 +44,7 @@ class Raster(object):
                  x_pixel, y_pixel, no_data_value, x_size, y_size):
         """
 
-        :param filename: A 2D numeric array of the raster values, North is up.
-                       The values are listed in 'English reading order' i.e.
-                       left-right and top-down.
+        :param filename: The raster file path string.
         :param upper_left_x: The longitude at the upper left corner of the
                              top left pixel.
         :param upper_left_y: The latitude at the upper left corner of the

--- a/hazimp/raster.py
+++ b/hazimp/raster.py
@@ -17,16 +17,13 @@
 
 """
 Manipulate raster data.
-
-Currently loads the entire raster layer into memory, which can blow out memory
-usage in some cases.
-
-# TODO: optimise raster loading and reading
 """
+import threading
+from concurrent.futures.thread import ThreadPoolExecutor
 
-import numpy
 import gdal
-from gdalconst import GA_ReadOnly, GDT_Float32
+import numpy
+from gdalconst import GA_ReadOnly
 
 
 class Raster(object):
@@ -43,11 +40,11 @@ class Raster(object):
     # R0913: 34:Raster.__init__: Too many arguments (9/6)
     # pylint: disable=R0902, R0913
 
-    def __init__(self, raster, upper_left_x, upper_left_y,
+    def __init__(self, filename, upper_left_x, upper_left_y,
                  x_pixel, y_pixel, no_data_value, x_size, y_size):
         """
 
-        :param raster: A 2D numeric array of the raster values, North is up.
+        :param filename: A 2D numeric array of the raster values, North is up.
                        The values are listed in 'English reading order' i.e.
                        left-right and top-down.
         :param upper_left_x: The longitude at the upper left corner of the
@@ -62,7 +59,7 @@ class Raster(object):
         :param y_size: Number of rows.
         :param no_data_value: Values in the raster that represent no data.
         """
-        self.raster = raster
+        self.filename = filename
         self.ul_x = upper_left_x
         self.ul_y = upper_left_y
         self.x_pixel = x_pixel
@@ -70,7 +67,6 @@ class Raster(object):
         self.no_data_value = no_data_value
         self.x_size = x_size
         self.y_size = y_size
-        self.raster[self.raster == self.no_data_value] = numpy.NAN
 
     @classmethod
     def from_file(cls, filename):
@@ -78,7 +74,7 @@ class Raster(object):
         Load a file in a raster file format known to GDAL.
         Note, image must be 'North up'.
 
-        :param filename: The csv file path string.
+        :param filename: The raster file path string.
         :returns: A Raster instance.
         """
 
@@ -99,40 +95,9 @@ class Raster(object):
         y_size = dataset.RasterYSize  # This will be a negative value.
         band = dataset.GetRasterBand(1)
         no_data_value = band.GetNoDataValue()
-        raster = band.ReadAsArray(0, 0, x_size, y_size, buf_type=GDT_Float32)
-        instance = cls(raster, upper_left_x, upper_left_y,
+        instance = cls(filename, upper_left_x, upper_left_y,
                        x_pixel, y_pixel, no_data_value, x_size, y_size)
-        return instance
 
-    @classmethod
-    def from_array(cls, raster, upper_left_x, upper_left_y,
-                   cell_size, no_data_value, dtype='float'):
-        """
-        Convert numeric array of raster data and info to a raster instance.
-        The values are listed in 'English reading order' i.e.
-        left-right and top-down.
-
-        :param raster: A 2D numeric array of the raster values, North is up.
-        :param upper_left_x: The longitude at the upper left corner.
-        :param upper_left_y: The latitude at the upper left corner.
-        :param cell_size: The cell size.
-        :param no_data_value: Values in the raster that represent no data.
-        :param dtype: Data type for the raster values (default float).
-        :returns: A Raster instance
-        """
-        raster = numpy.array(raster, dtype=dtype, copy=False)
-        if not len(raster.shape) == 2:
-            msg = ('Bad Raster shape %s' % (str(raster.shape)))
-            raise TypeError(msg)
-
-        x_size = raster.shape[1]
-        y_size = raster.shape[0]
-
-        x_pixel = cell_size
-        y_pixel = -cell_size
-
-        instance = cls(raster, upper_left_x, upper_left_y,
-                       x_pixel, y_pixel, no_data_value, x_size, y_size)
         return instance
 
     def raster_data_at_points(self, lon, lat):
@@ -168,11 +133,25 @@ class Raster(object):
             raw_row_offset = (lat - self.ul_y) / self.y_pixel
             row_offset = numpy.trunc(raw_row_offset).astype(int)
 
-            values[good_indexes] = self.raster[row_offset[good_indexes],
-                                               col_offset[good_indexes]]
-            # Change NODATA_value to NAN
-            values = numpy.where(values == self.no_data_value, numpy.NAN,
-                                 values)
+            data = threading.local()
+
+            def read_cell(i, x, y):
+                if 'band' not in data.__dict__:
+                    data.dataset = gdal.Open(self.filename, GA_ReadOnly)
+                    data.band = data.dataset.GetRasterBand(1)
+
+                values[i] = data.band.ReadAsArray(x, y, 1, 1)[0]
+
+            with ThreadPoolExecutor() as executor:
+                for index in good_indexes:
+                    executor.submit(read_cell, index,
+                                    col_offset[index].item(),
+                                    row_offset[index].item())
+
+        # Change NODATA_value to NAN
+        values = numpy.where(values == self.no_data_value, numpy.NAN,
+                             values)
+
         return values
 
     def extent(self):

--- a/tests/data/basic_raster.aai
+++ b/tests/data/basic_raster.aai
@@ -1,0 +1,8 @@
+ncols 3
+nrows 2
+xllcorner +0.
+yllcorner +8.
+cellsize 1
+NODATA_value -9999
+1 2 -9999
+4 5 6

--- a/tests/jobs/test_jobs.py
+++ b/tests/jobs/test_jobs.py
@@ -46,6 +46,7 @@ from hazimp.jobs import jobs
 from hazimp import context
 from hazimp import misc
 from hazimp import parallel
+from tests import CWD
 from tests.jobs.test_vulnerability_model import build_example1
 
 prov = mock.MagicMock(name='prov.model')
@@ -569,20 +570,11 @@ class TestJobs(unittest.TestCase):
         inst(con_in, **test_kwargs)
         os.remove(f.name)
 
-        raster = array([[1, 2, -9999], [4, 5, 6]])
-        upper_left_x = 0
-        upper_left_y = 10
-        cell_size = 1
-        no_data_value = -9999
         haz_v = 'haz_v'
         inst = JOBS[LOADRASTER]
         test_kwargs = {'attribute_label': haz_v,
                        'clip_exposure2all_hazards': True,
-                       'raster': raster,
-                       'upper_left_x': upper_left_x,
-                       'upper_left_y': upper_left_y,
-                       'cell_size': cell_size,
-                       'no_data_value': no_data_value}
+                       'file_list': [str(CWD / 'data/basic_raster.aai')]}
         inst(con_in, **test_kwargs)
 
         # There should be only no exposure points

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -31,9 +31,9 @@
 Test the raster module.
 """
 
-import unittest
-import tempfile
 import os
+import tempfile
+import unittest
 
 import numpy
 from scipy import asarray, allclose, nan
@@ -179,42 +179,6 @@ class TestRaster(unittest.TestCase):
         for a_file in files:
             os.remove(a_file)
 
-    def test3_raster_data_from_array(self):
-        # A test based on this info;
-        # http://en.wikipedia.org/wiki/Esri_grid
-        # Let's hope no one edits the data....
-        raster = [[-9999, -9999, 5, 2], [-9999, 20, 100, 36],
-                  [3, 8, 35, 10], [32, 42, 50, 6],
-                  [88, 75, 27, 9], [13, 5, 1, -9999]]
-        upper_left_x = 0.
-        upper_left_y = 300.
-        cell_size = 50.0
-        no_data_value = -9999
-
-        # Just outside the midpoint of all sides
-        lon = asarray([125, 125, 125, 125, 125, 125])
-        lat = asarray([275, 225, 175, 125, 75, 25])
-
-        raster = Raster.from_array(raster, upper_left_x, upper_left_y,
-                                   cell_size, no_data_value)
-        self.assertEqual(raster.ul_x, 0)
-        self.assertEqual(raster.ul_y, 300)
-        self.assertEqual(raster.x_pixel, 50)
-        self.assertEqual(raster.y_pixel, -50)
-        self.assertEqual(raster.x_size, 4)
-        self.assertEqual(raster.y_size, 6)
-
-        data = raster.raster_data_at_points(lon, lat)
-        self.assertTrue(allclose(data, asarray([5.0, 100.0, 35.0,
-                                                50.0, 27.0, 1.0])))
-
-        # testing extent
-        min_long, min_lat, max_long, max_lat = raster.extent()
-        self.assertEqual(min_long, 0)
-        self.assertEqual(min_lat, 0)
-        self.assertEqual(max_long, 200)
-        self.assertEqual(max_lat, 300)
-
     def test3_recalc_max(self):
         max_extent = (0, 0, 0, 0)
         extent = [-10, -20, 20, 40]
@@ -232,7 +196,6 @@ class TestRaster(unittest.TestCase):
         self.assertEqual(old_max_extent, max_extent)
 
 
-# -------------------------------------------------------------
 if __name__ == "__main__":
     Suite = unittest.makeSuite(TestRaster, 'test')
     Runner = unittest.TextTestRunner()

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -36,7 +36,7 @@ from hazimp.templates import (WINDNC, READERS, VULNFILE, PERMUTATION,
                               CALCSTRUCTLOSS, AGGREGATION, SAVE,
                               VULNSET, HAZARDRASTER, AGGREGATE, TABULATE,
                               SAVEAGG, WINDV5, CALCCONTLOSS, FLOODCONTENTSV2,
-                              FLOODFABRICV2, WINDV4, WINDV3)
+                              FLOODFABRICV2, WINDV4, WINDV3, EARTHQUAKEV1)
 from hazimp.templates.flood import CONT_ACTIONS, INSURE_PROB
 
 
@@ -49,7 +49,7 @@ class TestTemplates(unittest.TestCase):
             LOADCSVEXPOSURE: {
                 'file_name': 'exposure.csv'
             },
-            HAZARDRASTER: {},
+            HAZARDRASTER: {'file_list': 'hazard.tif'},
             VULNFILE: 'curve.xml',
             VULNSET: 'wind',
             SAVE: 'output.csv'
@@ -59,7 +59,7 @@ class TestTemplates(unittest.TestCase):
 
         self.assertJobs(jobs, [
             (LoadCsvExposure, {'file_name': 'exposure.csv'}),
-            (LoadRaster, {'attribute_label': '0.2s gust at 10m height m/s'}),
+            (LoadRaster, {'attribute_label': '0.2s gust at 10m height m/s', 'file_list': 'hazard.tif'}),
             (LoadXmlVulnerability, {'file_name': os.path.join(misc.RESOURCE_DIR, 'curve.xml')}),
             (SimpleLinker, {'vul_functions_in_exposure': {'wind': 'WIND_VULNERABILITY_FUNCTION_ID'}}),
             (SelectVulnFunction, {'variability_method': {'wind': 'mean'}}),
@@ -73,7 +73,7 @@ class TestTemplates(unittest.TestCase):
             LOADCSVEXPOSURE: {
                 'file_name': 'exposure.csv'
             },
-            HAZARDRASTER: {},
+            HAZARDRASTER: {'file_list': ['hazard.tif']},
             VULNFILE: 'curve.xml',
             VULNSET: 'wind',
             PERMUTATION: {},
@@ -90,10 +90,49 @@ class TestTemplates(unittest.TestCase):
 
         self.assertJobs(jobs, [
             (LoadCsvExposure, {'file_name': 'exposure.csv'}),
-            (LoadRaster, {'attribute_label': '0.2s gust at 10m height m/s'}),
+            (LoadRaster, {'attribute_label': '0.2s gust at 10m height m/s', 'file_list': ['hazard.tif']}),
             (LoadXmlVulnerability, {'file_name': os.path.join(misc.RESOURCE_DIR, 'curve.xml')}),
             (SimpleLinker, {'vul_functions_in_exposure': {'wind': 'WIND_VULNERABILITY_FUNCTION_ID'}}),
             (SelectVulnFunction, {'variability_method': {'wind': 'mean'}}),
+            (PermutateExposure, {}),
+            (MultipleDimensionMult, {'var1': 'structural',
+                                     'var2': 'REPLACEMENT_VALUE',
+                                     'var_out': 'structural_loss'}),
+            (AggregateLoss, {}),
+            (SaveAggregation, {'file_name': 'aggregation.csv'}),
+            (Categorise, {}),
+            (SaveExposure, {'file_name': 'output.csv'}),
+            (Aggregate, {}),
+            (Tabulate, {}),
+            (SaveProvenance, {'file_name': 'output.xml'})
+        ])
+
+    def test_template_earthquake_v1(self):
+        config = {
+            LOADCSVEXPOSURE: {
+                'file_name': 'exposure.csv'
+            },
+            HAZARDRASTER: {'file_list': 'hazard.tif'},
+            VULNFILE: 'curve.xml',
+            VULNSET: 'eq',
+            PERMUTATION: {},
+            CALCSTRUCTLOSS: {'replacement_value_label': 'REPLACEMENT_VALUE'},
+            AGGREGATION: {},
+            SAVEAGG: 'aggregation.csv',
+            CATEGORISE: {},
+            AGGREGATE: {},
+            TABULATE: {},
+            SAVE: 'output.csv'
+        }
+
+        jobs = READERS[EARTHQUAKEV1](config)
+
+        self.assertJobs(jobs, [
+            (LoadCsvExposure, {'file_name': 'exposure.csv'}),
+            (LoadRaster, {'attribute_label': 'MMI', 'file_list': 'hazard.tif'}),
+            (LoadXmlVulnerability, {'file_name': os.path.join(misc.RESOURCE_DIR, 'curve.xml')}),
+            (SimpleLinker, {'vul_functions_in_exposure': {'eq': 'EQ_VULNERABILITY_FUNCTION_ID'}}),
+            (SelectVulnFunction, {'variability_method': {'eq': 'mean'}}),
             (PermutateExposure, {}),
             (MultipleDimensionMult, {'var1': 'structural',
                                      'var2': 'REPLACEMENT_VALUE',
@@ -112,7 +151,7 @@ class TestTemplates(unittest.TestCase):
             LOADCSVEXPOSURE: {
                 'file_name': 'exposure.csv'
             },
-            HAZARDRASTER: {},
+            HAZARDRASTER: {'file_list': 'hazard.tif'},
             VULNFILE: 'curve.xml',
             VULNSET: 'wind',
             PERMUTATION: {},


### PR DESCRIPTION
* No longer reads the entire raster into memory, reads only the cells defined in the exposure data
* Removed the ability to pass an in-memory array via 'from_array'
* Added a 'ThreadPoolExecutor' for some performance improvement when reading hazard data for large exposure datasets