### PR TITLE
Enable `hazimp` to run using netcdf files

### DIFF
--- a/hazimp.yml
+++ b/hazimp.yml
@@ -28,3 +28,4 @@ dependencies:
   - pytest-cov
   - mock
   - lxml
+  - xarray

--- a/hazimp.yml
+++ b/hazimp.yml
@@ -29,4 +29,3 @@ dependencies:
   - mock
   - lxml
   - xarray
-  - rasterio

--- a/hazimp.yml
+++ b/hazimp.yml
@@ -29,3 +29,4 @@ dependencies:
   - mock
   - lxml
   - xarray
+  - rasterio

--- a/hazimp/raster.py
+++ b/hazimp/raster.py
@@ -187,11 +187,13 @@ def files_raster_data_at_points(lon, lat, files):
     for filename in files:
         if filename.endswith(".nc"):
             ds = xr.open_dataset(filename)
-            # TODO: this uses the first band - enable band to be chosen or maybe iterate through bands
+            # TODO: this uses the first band - enable band to be chosen
+            #  or maybe iterate through bands
             band_name = next(
                 band for band in ds.data_vars if ds[band].size > 1)
             band = ds[band_name].squeeze()
-            # Note: this assume the input data is in (lat, lon) format - is this always applicable?
+            # Note: this assume the input data is in (lat, lon) format
+            # - is this always applicable?
             ydim, xdim = band.dims
             results = band.interp(
                 {ydim: xr.DataArray(lat, dims="z"),

--- a/hazimp/raster.py
+++ b/hazimp/raster.py
@@ -190,7 +190,6 @@ def files_raster_data_at_points(lon, lat, files):
             # TODO: this uses the first band - enable band to be chosen or maybe iterate through bands
             band_name = next(
                 band for band in ds.data_vars if ds[band].size > 1)
-            print(band_name)
             band = ds[band_name].squeeze()
             # Note: this assume the input data is in (lat, lon) format - is this always applicable?
             ydim, xdim = band.dims

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -215,7 +215,15 @@ class TestRaster(unittest.TestCase):
         # lat 8 - 10
 
         nc_filename = 'test.nc'
-        ds = xr.load_dataset(f.name, engine='rasterio')
+        data = numpy.array([
+            [1.0, 2.0, 3.0],
+            [4.0, 5.0, 6.0],
+        ])
+        ds = xr.DataArray(
+            data,
+            dict(y=numpy.array([9.5, 8.5]), x=numpy.array([0.5, 1.5, 2.5])),
+            ('y', 'x')
+        )
         ds.to_netcdf(nc_filename)
 
         lon = asarray([0.8, 2.1, 2.5, 4.0, 20])


### PR DESCRIPTION
This PR enables `files_raster_data_at_points` to use netcdf files so that `hazimp` can be run with the wind gusts files (without multipliers applied). A limitation is that only the first band is loaded in which is sufficient for this use case, and the `tif`  processing code does the same thing.