### PR TITLE
Add lower quantile for permutations

### DIFF
--- a/hazimp/main.py
+++ b/hazimp/main.py
@@ -95,7 +95,7 @@ def cli():
     logging.basicConfig(
         level=logging.INFO,
         format='%(asctime)s: %(name)s: %(levelname)s: %(message)s',
-        datefmt='%y-%m-%d %H:%M:%s')
+        datefmt='%Y-%m-%d %H:%M:%S')
 
     CMD_LINE_ARGS = console.cmd_line()
     if CMD_LINE_ARGS:


### PR DESCRIPTION
To assist with understanding scale of uncertainty arising from exposure definition, we include a lower bound on the losses for each asset. This changes the default behaviour from only an upper bound, to having upper and lower bounds. Default is to use [0.05, 0.95] as the quantiles for evaluation lower and upper bounds. 