### PR TITLE
#61 Fix insertion of underscores

### DIFF
--- a/hazimp/aggregate.py
+++ b/hazimp/aggregate.py
@@ -209,7 +209,8 @@ def aggregate_loss_atts(dframe, groupby=None, kwargs=None):
         LOGGER.exception(f"No field named {groupby} in the exposure data")
         sys.exit(1)
     outdf = grouped.agg(kwargs)
-    outdf.columns = ['_'.join(col).strip() for col in outdf.columns.values]
+
+    outdf.columns = ['_'.join(col).rstrip('_') for col in outdf.columns.values]
     outdf.reset_index(col_level=1)
     outdf.columns = outdf.columns.get_level_values(0)
     return outdf

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -103,10 +103,16 @@ class TestAggregate(unittest.TestCase):
         self.assertFalse(status)
 
     def test_aggregate_loss_atts(self):
-        data_frame = pd.DataFrame({'A': ['X', 'Y', 'Y'], 'B': [1, 2, 3]})
-        aggregated = aggregate_loss_atts(data_frame, 'A', {'B': 'sum'})
+        data_frame = pd.DataFrame({'AA': ['X', 'Y', 'Y'], 'B': [1, 2, 3]})
+        aggregated = aggregate_loss_atts(data_frame, 'AA', {'B': ['sum']})
 
-        assert_frame_equal(pd.DataFrame({'A': ['X', 'Y'], 'B': [1, 5]}), aggregated)
+        assert_frame_equal(pd.DataFrame({'AA': ['X', 'Y'], 'B_sum': [1, 5]}), aggregated)
+
+    def test_aggregate_loss_atts_multifunc(self):
+        data_frame = pd.DataFrame({'AA': ['X', 'Y', 'Y'], 'B': [1, 2, 3]})
+        aggregated = aggregate_loss_atts(data_frame, 'AA', {'B': ['sum', 'mean']})
+
+        assert_frame_equal(pd.DataFrame({'AA': ['X', 'Y'], 'B_sum': [1, 5], 'B_mean': [1, 2.5]}), aggregated)
 
     def test_aggregate_loss_atts_invalid_field(self):
         with self.assertRaises(SystemExit) as context:


### PR DESCRIPTION
Fixes a bug that inserted underscores between each letter in field names for aggregated data (#61 )