### PR TITLE
AH-1801 Make aggregation field types consistent

### DIFF
--- a/.github/workflows/hazimp-tests.yml
+++ b/.github/workflows/hazimp-tests.yml
@@ -36,6 +36,7 @@ jobs:
       with:
         mamba-version: "*"
         channels: conda-forge,defaults
+        channel-priority: true
         python-version: ${{ matrix.python-version }}
         activate-environment: hazimp
         environment-file: hazimp.yml

--- a/.github/workflows/hazimp-tests.yml
+++ b/.github/workflows/hazimp-tests.yml
@@ -16,6 +16,9 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]
+    defaults:
+      run:
+        shell: bash -l {0}
 
     steps:
     - uses: actions/checkout@v3
@@ -29,11 +32,11 @@ jobs:
           ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{hashFiles('hazimp.yml') }}
 
     - name: Set up environment
-      uses: conda-incubator/setup-miniconda@v2.2.0
+      uses: conda-incubator/setup-miniconda@v2
       with:
-        python-version: ${{ matrix.python-version }}
-        channels: conda-forge,defaults
         mamba-version: "*"
+        channels: conda-forge,defaults
+        python-version: ${{ matrix.python-version }}
         activate-environment: hazimp
         environment-file: hazimp.yml
         auto-activate-base: false

--- a/.github/workflows/hazimp-tests.yml
+++ b/.github/workflows/hazimp-tests.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Set up environment
       uses: conda-incubator/setup-miniconda@v2
       with:
-        mamba-version: "*"
+        miniforge-variant: Mambaforge
         channels: conda-forge,defaults
         channel-priority: true
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/hazimp-tests.yml
+++ b/.github/workflows/hazimp-tests.yml
@@ -13,12 +13,12 @@ jobs:
   Hazimp:
     name: Test HazImp
     runs-on: ubuntu-latest
-    strategy: 
+    strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Cache conda
       uses: actions/cache@v2
       env:
@@ -27,9 +27,9 @@ jobs:
         path: ~/conda_pkgs_dir
         key:
           ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{hashFiles('hazimp.yml') }}
-          
+
     - name: Set up environment
-      uses: conda-incubator/setup-miniconda@v2.0.0
+      uses: conda-incubator/setup-miniconda@v2.2.0
       with:
         python-version: ${{ matrix.python-version }}
         channels: conda-forge,defaults

--- a/hazimp/aggregate.py
+++ b/hazimp/aggregate.py
@@ -9,7 +9,7 @@ from os.path import abspath, isdir, dirname
 import geopandas
 import pandas as pd
 import numpy as np
-
+from hazimp.misc import check_data_type
 LOGGER = logging.getLogger(__name__)
 
 # List of possible drivers for output:
@@ -91,6 +91,19 @@ def choropleth(dframe, boundaries, impactcode, bcode, filename,
 
     left, right = impactcode, bcode
 
+    shapes = geopandas.read_file(boundaries)
+    try:
+        dtype = check_data_type(shapes[right])
+    except KeyError:
+        LOGGER.exception(f"Aggregation boundaries have no attribute '{right}'")
+        sys.exit(1)
+
+    try:
+        dframe[left] = dframe[left].astype(dtype)
+    except:
+        LOGGER.exception(f"Cannot convert {left} to {dtype}")
+        sys.exit(1)
+
     aggregate = dframe.groupby(left).agg(fields).reset_index()
     aggregate.columns = [
         '_'.join(columns).rstrip('_') for columns in aggregate.columns.values
@@ -111,18 +124,7 @@ def choropleth(dframe, boundaries, impactcode, bcode, filename,
     else:
         aggregate.set_index(left, inplace=True)
 
-    shapes = geopandas.read_file(boundaries)
-
-    try:
-        shapes['key'] = shapes[right].astype(np.int64)
-    except KeyError:
-        LOGGER.error(f"{boundaries} does not contain an attribute {right}")
-        sys.exit(1)
-    except OverflowError:
-        LOGGER.error(f"Unable to convert {right} values to ints")
-        sys.exit(1)
-
-    result = shapes.merge(aggregate, left_on='key', right_index=True)
+    result = shapes.merge(aggregate, left_on=right, right_index=True)
 
     fileext = os.path.splitext(filename)[1].replace('.', '')
     try:

--- a/hazimp/aggregate.py
+++ b/hazimp/aggregate.py
@@ -100,7 +100,7 @@ def choropleth(dframe, boundaries, impactcode, bcode, filename,
 
     try:
         dframe[left] = dframe[left].astype(dtype)
-    except:
+    except ValueError:
         LOGGER.exception(f"Cannot convert {left} to {dtype}")
         sys.exit(1)
 

--- a/hazimp/misc.py
+++ b/hazimp/misc.py
@@ -454,3 +454,17 @@ def upload_to_s3_if_applicable(local_path, bucket_name, bucket_key,
         if not ignore_exception:
             LOGGER.exception("S3 write error: {0}".format(local_path))
             raise e
+
+def check_data_type(data):
+    """
+    Function to check the data type of a given attribute
+
+    :param data: Sample of the data
+    :type data: `pd.Series` or `pd.DataFrame`
+    """
+    try:
+        dtype = data[0].dtype
+    except AttributeError:
+        dtype = type(data[0])
+
+    return dtype

--- a/hazimp/misc.py
+++ b/hazimp/misc.py
@@ -455,6 +455,7 @@ def upload_to_s3_if_applicable(local_path, bucket_name, bucket_key,
             LOGGER.exception("S3 write error: {0}".format(local_path))
             raise e
 
+
 def check_data_type(data):
     """
     Function to check the data type of a given attribute


### PR DESCRIPTION
A fix for the way we handle comparing the key fields when joining the unit data to geospatial data. Previously, the key field in the geospatial boundary data was converted to an int64 data type, but the raw data may be actually strings or other data types. Instead, we now convert the attribute in the point data to match the data type of the attribute in the boundary data. The field from the boundary data is used in the output file, so these will now be consistent.