### PR TITLE
NHIRS-209 bugfix for inexplicable pd.merge errors

### DIFF
--- a/hazimp/aggregate.py
+++ b/hazimp/aggregate.py
@@ -117,7 +117,7 @@ def choropleth(dframe, boundaries, impactcode, bcode, filename,
     if categories and (field_name in dframe.columns):
         dsg = dframe.pivot_table(index=left, columns=field_name,
                                  aggfunc='size', fill_value=0)
-        dsg.rename({dsg.columns[0]:dsg.columns[0]}, inplace=True, axis=1)
+        dsg.rename({dsg.columns[0]: dsg.columns[0]}, inplace=True, axis=1)
         aggregate = aggregate.merge(dsg, on=left).set_index(left)
     elif categories and (field_name not in dframe.columns):
         LOGGER.warning("No categorisation will be performed")

--- a/hazimp/aggregate.py
+++ b/hazimp/aggregate.py
@@ -117,6 +117,7 @@ def choropleth(dframe, boundaries, impactcode, bcode, filename,
     if categories and (field_name in dframe.columns):
         dsg = dframe.pivot_table(index=left, columns=field_name,
                                  aggfunc='size', fill_value=0)
+        dsg.rename({dsg.columns[0]:dsg.columns[0]}, inplace=True, axis=1)
         aggregate = aggregate.merge(dsg, on=left).set_index(left)
     elif categories and (field_name not in dframe.columns):
         LOGGER.warning("No categorisation will be performed")


### PR DESCRIPTION
`pd.merge` in `aggregate.py` started throwing InvalidIndexError when merging the aggregate and pivot_table outputs. The fix renames the first column with itself, which seems to repair the indexing and allows the merge to be done without error.